### PR TITLE
Python2 and Python3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.pyc
+__pycache__/

--- a/plugins/DNSDetection/__init__.py
+++ b/plugins/DNSDetection/__init__.py
@@ -1,9 +1,6 @@
-"""DNSDetection plugin performs CDN detection through nslookup results."""
+#!/usr/bin/env python
+"""
+DNSDetection plugin performs CDN detection through nslookup results.
+"""
 
-import sys
-
-sys.path.insert(0, 'plugins/')
-
-from DNSDetection.behaviors import detect
-
-sys.path.pop(0)
+from plugins.DNSDetection.behaviors import detect

--- a/plugins/DNSDetection/behaviors.py
+++ b/plugins/DNSDetection/behaviors.py
@@ -1,12 +1,20 @@
-import commands
+#!/usr/bin/env python
+from __future__ import print_function
 import sys
-import urlparse
 import re
-
 from utils import CDNEngine
 
+if sys.version_info >= (3, 0):
+    import subprocess as commands
+    import urllib.parse as urlparse
+else:
+    import commands
+    import urlparse
+
+
 def detect(hostname):
-    """Performs CDN detection through the DNS, using the nslookup command.
+    """
+    Performs CDN detection through the DNS, using the nslookup command.
 
     Parameters
     ----------
@@ -14,7 +22,7 @@ def detect(hostname):
         Hostname to assess
     """
 
-    print '[+] DNS detection\n'
+    print('[+] DNS detection\n')
 
     hostname = urlparse.urlparse(hostname).netloc
     regexp = re.compile('\\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\\b')

--- a/plugins/ErrorServerDetection/__init__.py
+++ b/plugins/ErrorServerDetection/__init__.py
@@ -1,12 +1,8 @@
-"""ErrorServerDetection plugin performs CDN detection when attempts to access 
+#!/usr/bin/env python
+"""
+ErrorServerDetection plugin performs CDN detection when attempts to access
 the web server via its IP address fail and disclose information about
 the CDN in place.
 """
 
-import sys
-
-sys.path.insert(0, 'plugins/')
-
-from ErrorServerDetection.behaviors import detect
-
-sys.path.pop(0)
+from plugins.ErrorServerDetection.behaviors import detect

--- a/plugins/ErrorServerDetection/behaviors.py
+++ b/plugins/ErrorServerDetection/behaviors.py
@@ -1,13 +1,21 @@
-import commands
-import re
+#!/usr/bin/env python
+from __future__ import print_function
 import sys
-import urlparse
-
+import re
 from utils import CDNEngine
 from utils import request
 
+if sys.version_info >= (3, 0):
+    import subprocess as commands
+    import urllib.parse as urlparse
+else:
+    import commands
+    import urlparse
+
+
 def detect(hostname):
-    """Performs CDN detection thanks to information disclosure from server error.
+    """
+    Performs CDN detection thanks to information disclosure from server error.
 
     Parameters
     ----------
@@ -15,7 +23,7 @@ def detect(hostname):
         Hostname to assess
     """
 
-    print '[+] Error server detection\n'
+    print('[+] Error server detection\n')
 
     hostname = urlparse.urlparse(hostname).netloc
     regexp = re.compile('\\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\\b')
@@ -25,5 +33,5 @@ def detect(hostname):
 
     for addr in addresses:
         res = request.do('http://' + addr.group())
-        if res != None and res.status_code == 500:
+        if res is not None and res.status_code == 500:
             CDNEngine.find(res.text.lower())

--- a/plugins/HTTPHeaderDetection/__init__.py
+++ b/plugins/HTTPHeaderDetection/__init__.py
@@ -1,9 +1,6 @@
-"""HTTPHeaderDetection plugin performs CDN detection by assessing HTTP headers."""
+#!/usr/bin/env python
+"""
+HTTPHeaderDetection plugin performs CDN detection by assessing HTTP headers.
+"""
 
-import sys
-
-sys.path.insert(0, 'plugins/')
-
-from HTTPHeaderDetection.behaviors import detect
-
-sys.path.pop(0)
+from plugins.HTTPHeaderDetection.behaviors import detect

--- a/plugins/HTTPHeaderDetection/behaviors.py
+++ b/plugins/HTTPHeaderDetection/behaviors.py
@@ -1,11 +1,18 @@
+#!/usr/bin/env python
+from __future__ import print_function
 import sys
-import urlparse
-
 from utils import CDNEngine
 from utils import request
 
+if sys.version_info >= (3, 0):
+    import urllib.parse as urlparse
+else:
+    import urlparse
+
+
 def detect(hostname):
-    """Performs CDN detection thanks to HTTP headers.
+    """
+    Performs CDN detection thanks to HTTP headers.
 
     Parameters
     ----------
@@ -13,7 +20,7 @@ def detect(hostname):
         Hostname to assess
     """
 
-    print '[+] HTTP header detection\n'
+    print('[+] HTTP header detection\n')
 
     hostname = urlparse.urlparse(hostname).scheme + '://' + urlparse.urlparse(hostname).netloc
 
@@ -27,12 +34,12 @@ def detect(hostname):
 
     res = request.do(hostname)
 
-    if res == None:
+    if res is None:
         return
 
     for field, state in fields.items():
         value = res.headers.get(field)
-        if state and value != None:
+        if state and value is not None:
             CDNEngine.find(value.lower())
-        elif not state and value != None:
+        elif not state and value is not None:
             CDNEngine.find(field.lower())

--- a/plugins/SubdomainDetection/__init__.py
+++ b/plugins/SubdomainDetection/__init__.py
@@ -1,12 +1,8 @@
-"""CDN are, sometimes, deployed on a specific subdomain. SubdomainDetection
+#!/usr/bin/env python
+"""
+CDN are, sometimes, deployed on a specific subdomain. SubdomainDetection
 plugin performs CDN detection by trying to access this specific subdomain and
 by analyzing its DNS.
 """
 
-import sys
-
-sys.path.insert(0, 'plugins/')
-
-from SubdomainDetection.behaviors import detect
-
-sys.path.pop(0)
+from plugins.SubdomainDetection.behaviors import detect

--- a/plugins/SubdomainDetection/behaviors.py
+++ b/plugins/SubdomainDetection/behaviors.py
@@ -1,10 +1,19 @@
-import commands
-import urlparse
-
+#!/usr/bin/env python
+from __future__ import print_function
+import sys
 from utils import CDNEngine
 
+if sys.version_info >= (3, 0):
+    import subprocess as commands
+    import urllib.parse as urlparse
+else:
+    import commands
+    import urlparse
+
+
 def detect(hostname):
-    """Performs CDN detection by trying to access the cdn subdomain of the
+    """
+    Performs CDN detection by trying to access the cdn subdomain of the
     specified hostname.
 
     Parameters
@@ -13,7 +22,7 @@ def detect(hostname):
         Hostname to assess
     """
 
-    print '[+] CDN subdomain detection\n'
+    print('[+] CDN subdomain detection\n')
 
     hostname = "cdn." + urlparse.urlparse(hostname).netloc
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+from . import * # import all plugins

--- a/utils/CDNEngine.py
+++ b/utils/CDNEngine.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+from __future__ import print_function
 import sys
 
 CDN = {
@@ -16,8 +18,10 @@ CDN = {
     'msecnd.ne': 'Microsoft Azure - https://azure.microsoft.com/en-us/services/cdn/'
 }
 
+
 def find(data):
-    """Compares the provided data to the CDN supported.
+    """
+    Compares the provided data to the CDN supported.
 
     Parameters
     ----------
@@ -27,5 +31,5 @@ def find(data):
 
     for keyword, description in CDN.items():
         if data.find(keyword.lower()) != -1:
-            print '\033[1;32mCDN found: ' + description + '\033[1;m\n'
+            print('\033[1;32mCDN found: ' + description + '\033[1;m\n')
             sys.exit(0)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python2

--- a/utils/loader.py
+++ b/utils/loader.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import imp
 import os
 
@@ -5,7 +6,9 @@ PluginFolder = "./plugins"
 MainModule = "__init__"
 
 def getPlugins():
-    """List the plugins located in the plugins folder."""
+    """
+    List the plugins located in the plugins folder.
+    """
 
     plugins = []
     pluginList = os.listdir(PluginFolder)
@@ -18,7 +21,8 @@ def getPlugins():
     return plugins
 
 def loadPlugin(plugin):
-    """Loads the specified plugin.
+    """
+    Loads the specified plugin.
 
     Parameters
     ----------

--- a/utils/request.py
+++ b/utils/request.py
@@ -1,17 +1,24 @@
+#!/usr/bin/env python
+from __future__ import print_function
 import signal
 import requests
 
 class TimeoutException(Exception):
-    """ Exception called on timeouts. """
+    """
+    Exception called on timeouts.
+    """
     pass
 
 def requestTimeout(signum, frame):
-    """ Request timeout. """
+    """
+    Request timeout.
+    """
 
     raise TimeoutException()
 
 def do(hostname):
-    """Performs a GET request.
+    """
+    Performs a GET request.
 
     Parameters
     ----------
@@ -27,11 +34,11 @@ def do(hostname):
         return requests.get(hostname, timeout=10)
 
     except TimeoutException:
-        print "\033[1;31mRequest timeout: test aborted\n\033[1;m"
+        print("\033[1;31mRequest timeout: test aborted\n\033[1;m")
         return None
 
     except requests.ConnectionError:
-        print "\033[1;31mServer not found: test aborted\n\033[1;m"
+        print("\033[1;31mServer not found: test aborted\n\033[1;m")
         return None
 
     finally:

--- a/whichCDN.py
+++ b/whichCDN.py
@@ -1,12 +1,17 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python
+from __future__ import print_function
 import argparse
-import urlparse
 import signal
 import sys
 
 from utils import loader
 from utils import request
+
+if sys.version_info >= (3, 0):
+    import urllib.parse as urlparse
+else:
+    import urlparse
+
 
 def parser():
     """Parse arguments."""
@@ -21,6 +26,7 @@ def parser():
     parser.add_argument('target', type=str, help='hostname to scan')
 
     parser.parse_args()
+
 
 def sanitizeURL(hostname):
     """Sanitizes the hostname by adding the http protocol if it has not been
@@ -41,24 +47,27 @@ def sanitizeURL(hostname):
     hostname = "http://" + hostname if components.scheme == '' else hostname
     return hostname
 
-print """\
- __      __.__    .__       .__    _________ ________    _______
-/  \    /  \  |__ |__| ____ |  |__ \_   ___ \\\\______ \   \      \\
-\   \/\/   /  |  \|  |/ ___\|  |  \/    \  \/ |    |  \  /   |   \\
- \        /|   Y  \  \  \___|   Y  \     \____|    `   \/    |    \\
-  \__/\  / |___|  /__|\___  >___|  /\______  /_______  /\____|__  /
-       \/       \/        \/     \/        \/        \/         \/
-"""
 
-parser()
+if __name__ == "__main__":
 
-signal.signal(signal.SIGALRM, request.requestTimeout)
-signal.alarm(5)
+    print("""
+     __      __.__    .__       .__    _________ ________    _______
+    /  \    /  \  |__ |__| ____ |  |__ \_   ___ \\\\______ \   \      \\
+    \   \/\/   /  |  \|  |/ ___\|  |  \/    \  \/ |    |  \  /   |   \\
+     \        /|   Y  \  \  \___|   Y  \     \____|    `   \/    |    \\
+      \__/\  / |___|  /__|\___  >___|  /\______  /_______  /\____|__  /
+           \/       \/        \/     \/        \/        \/         \/
+    """)
 
-hostname = sanitizeURL(sys.argv[1])
+    parser()
 
-for module in loader.getPlugins():
-    plugin = loader.loadPlugin(module)
-    plugin.detect(hostname)
+    signal.signal(signal.SIGALRM, request.requestTimeout)
+    signal.alarm(5)
 
-print '\033[1;31mNo CDN found\033[1;m'
+    hostname = sanitizeURL(sys.argv[1])
+
+    for module in loader.getPlugins():
+        plugin = loader.loadPlugin(module)
+        plugin.detect(hostname)
+
+    print('\033[1;31mNo CDN found\033[1;m')

--- a/whichCDN.py
+++ b/whichCDN.py
@@ -13,8 +13,14 @@ else:
     import urlparse
 
 
+def gracefulExit(signal, frame):
+    sys.exit(0)
+
+
 def parser():
-    """Parse arguments."""
+    """
+    Parse arguments.
+    """
 
     parser = argparse.ArgumentParser(description="""\
         WhichCDN allows to detect if a given website is protected by a Content
@@ -29,7 +35,8 @@ def parser():
 
 
 def sanitizeURL(hostname):
-    """Sanitizes the hostname by adding the http protocol if it has not been
+    """
+    Sanitizes the hostname by adding the http protocol if it has not been
     provided.
 
     Parameters
@@ -62,6 +69,7 @@ if __name__ == "__main__":
     parser()
 
     signal.signal(signal.SIGALRM, request.requestTimeout)
+    signal.signal(signal.SIGINT, gracefulExit)
     signal.alarm(5)
 
     hostname = sanitizeURL(sys.argv[1])


### PR DESCRIPTION
- Updated shebang to detect python path instead of forcing the use of
  /usr/bin/python
- Made docstring more readable
- Made script python3 compatible using print_functions and importing
  module based on python version
- Refactored plugin submodule by creating a global plugin submodule to
  allow standard import in plugin modules
- Added a real main function (test that the script is run and not imported)
- Fixed some linter warning (comparison with None that should be done
  with 'is' and 'is not' instead of '==' and '!=')
  See: https://jaredgrubb.blogspot.fr/2009/04/python-is-none-vs-none.html
- Handle sigint gracefuly